### PR TITLE
refactor: Improvement - Enhance domain and final class for non extandable

### DIFF
--- a/forex-mtl/build.sbt
+++ b/forex-mtl/build.sbt
@@ -43,8 +43,7 @@ scalacOptions ++= Seq(
   "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
   "-Ywarn-unused:privates", // Warn if a private member is unused.
   "-Ycache-plugin-class-loader:last-modified", // Enables caching of classloaders for compiler plugins
-  "-Ycache-macro-class-loader:last-modified", // and macro definitions. This can lead to performance improvements.
-  "-Ymacro-annotations"
+  "-Ycache-macro-class-loader:last-modified" // and macro definitions. This can lead to performance improvements
 )
 
 resolvers +=
@@ -63,7 +62,6 @@ libraryDependencies ++= Seq(
   Libraries.circeGeneric,
   Libraries.circeGenericExt,
   Libraries.circeParser,
-  Libraries.newType,
   Libraries.pureConfig,
   Libraries.ip4s,
   Libraries.logback,

--- a/forex-mtl/project/Dependencies.scala
+++ b/forex-mtl/project/Dependencies.scala
@@ -9,7 +9,6 @@ object Dependencies {
     val http4s     = "0.23.18"
     val circe      = "0.14.3" /* Do not upgrade more than 0.14.3 */
 
-    val newType       = "0.4.4"
     val pureConfig    = "0.17.4"
     val ip4s          = "3.3.0"
     val kindProjector = "0.13.2"
@@ -44,9 +43,6 @@ object Dependencies {
     lazy val circeGeneric    = circe("circe-generic")
     lazy val circeGenericExt = circe("circe-generic-extras")
     lazy val circeParser     = circe("circe-parser")
-
-    // Newtype
-    lazy val newType = "io.estatico" %% "newtype" % Versions.newType
 
     // Config
     lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % Versions.pureConfig

--- a/forex-mtl/src/main/scala/forex/Module.scala
+++ b/forex-mtl/src/main/scala/forex/Module.scala
@@ -15,7 +15,7 @@ import org.http4s.client.Client
 import org.http4s.server.middleware.{ AutoSlash, Timeout }
 import org.typelevel.log4cats.Logger
 
-class Module[F[_]: Async: Logger](config: ApplicationConfig, httpClient: Client[F], locks: BucketLocks[F]) {
+final class Module[F[_]: Async: Logger](config: ApplicationConfig, httpClient: Client[F], locks: BucketLocks[F]) {
 
   private val oneFrameClient: OneFrameClient[F] = config.environment match {
     case Environment.Dev =>

--- a/forex-mtl/src/main/scala/forex/clients/oneframe/errors.scala
+++ b/forex-mtl/src/main/scala/forex/clients/oneframe/errors.scala
@@ -26,10 +26,12 @@ object errors {
       case _                              => AppError.UnexpectedError("Unexpected error")
     }
 
-  def toAppError(status: Int): AppError =
+  def toAppError(service: String, message: String): AppError = AppError.DecodingFailed(service, message)
+
+  def toAppError(status: Int, body: String = ""): AppError =
     status match {
       case 400 =>
-        AppError.BadRequest(s"Bad request")
+        AppError.BadRequest(s"Bad request: $body")
       case 401 | 403 =>
         AppError.UpstreamAuthFailed("one-frame", "Upstream service authentication failed")
       case 404 =>
@@ -37,7 +39,7 @@ object errors {
       case 429 =>
         AppError.RateLimited("one-frame", "Rate limited")
       case x if x >= 500 =>
-        AppError.UpstreamUnavailable("one-frame", s"Upstream error $x")
+        AppError.UpstreamUnavailable("one-frame", s"Upstream error $x: $body")
       case _ =>
         AppError.UnexpectedError("Unexpected error")
     }

--- a/forex-mtl/src/main/scala/forex/domain/rates/PivotRate.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/PivotRate.scala
@@ -4,7 +4,7 @@ import forex.domain.currency.Currency
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.{ Decoder, Encoder }
 
-import java.time.OffsetDateTime
+import java.time.{ OffsetDateTime, ZoneOffset }
 
 final case class PivotRate(currency: Currency, price: Price, timestamp: Timestamp)
 
@@ -13,7 +13,7 @@ object PivotRate {
   implicit val pairEncoder: Encoder[PivotRate] = deriveEncoder[PivotRate]
 
   def default(currency: Currency): PivotRate =
-    PivotRate(currency, Price(BigDecimal(1)), Timestamp.now)
+    PivotRate(currency, Price(BigDecimal(1)), Timestamp(OffsetDateTime.now(ZoneOffset.UTC)))
 
   def fromResponse(currency: Currency, price: BigDecimal, time_stamp: String): PivotRate =
     PivotRate(currency, Price(price), Timestamp(OffsetDateTime.parse(time_stamp)))

--- a/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
@@ -1,6 +1,6 @@
 package forex.domain.rates
 
-import io.circe.{Decoder, Encoder}
+import io.circe.{ Decoder, Encoder }
 
 final case class Price(value: BigDecimal) extends AnyVal
 object Price {

--- a/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
@@ -2,11 +2,19 @@ package forex.domain.rates
 
 import io.circe.{ Decoder, Encoder }
 
+import scala.math.BigDecimal.RoundingMode
+
 final case class Price(value: BigDecimal) extends AnyVal
 object Price {
-  def fromInt(value: Integer): Price =
-    Price(BigDecimal(value))
+  private val Scale = 10
+  private val Mode  = RoundingMode.HALF_UP
+
+  private def fromBigDecimal(n: BigDecimal): Either[String, Price] =
+    if (n.signum < 0) Left("Price must be non-negative")
+    else Right(new Price(n.setScale(Scale, Mode)))
+
+  def fromInt(n: Int): Either[String, Price] = fromBigDecimal(BigDecimal(n))
 
   implicit val encoder: Encoder[Price] = Encoder.encodeBigDecimal.contramap(_.value)
-  implicit val decoder: Decoder[Price] = Decoder.decodeBigDecimal.map(Price.apply)
+  implicit val decoder: Decoder[Price] = Decoder.decodeBigDecimal.emap(fromBigDecimal)
 }

--- a/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
@@ -1,11 +1,10 @@
 package forex.domain.rates
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{Decoder, Encoder}
 
 final case class Price(value: BigDecimal) extends AnyVal
-
 object Price {
-  def apply(value: Integer): Price =
+  def fromInt(value: Integer): Price =
     Price(BigDecimal(value))
 
   implicit val encoder: Encoder[Price] = Encoder.encodeBigDecimal.contramap(_.value)

--- a/forex-mtl/src/main/scala/forex/domain/rates/Rate.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Rate.scala
@@ -24,7 +24,7 @@ object Rate {
       case (_, USD) =>
         (1.0 / pivotBase.price.value, pivotBase.timestamp)
       case (_, _) =>
-        (pivotQuote.price.value / pivotBase.price.value, Timestamp.olderTTL(pivotBase.timestamp, pivotQuote.timestamp))
+        (pivotQuote.price.value / pivotBase.price.value, Timestamp.older(pivotBase.timestamp, pivotQuote.timestamp))
     }
 
     Rate(

--- a/forex-mtl/src/main/scala/forex/domain/rates/Timestamp.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Timestamp.scala
@@ -1,7 +1,11 @@
 package forex.domain.rates
 
-import java.time.{ OffsetDateTime, ZoneOffset }
+import java.time.{ Duration, Instant, OffsetDateTime, ZoneOffset }
 import io.circe.{ Decoder, Encoder }
+import cats.effect.Clock
+import cats.syntax.either._
+import cats.syntax.functor._
+import cats.Functor
 
 import java.time.format.DateTimeFormatter
 import scala.concurrent.duration.FiniteDuration
@@ -9,24 +13,30 @@ import scala.concurrent.duration.FiniteDuration
 final case class Timestamp(value: OffsetDateTime) extends AnyVal
 
 object Timestamp {
-  def now: Timestamp = Timestamp(OffsetDateTime.now(ZoneOffset.UTC))
 
-  def isWithinTTL(timestamp: Timestamp, ttl: FiniteDuration): Boolean = {
-    val now  = OffsetDateTime.now
-    val diff = java.time.Duration.between(timestamp.value, now)
-    diff.compareTo(java.time.Duration.ofSeconds(ttl.toSeconds)) < 0
-  }
-
-  def olderTTL(t1: Timestamp, t2: Timestamp): Timestamp = if (t1.value.isBefore(t2.value)) t1 else t2
-
-  implicit val encoder: Encoder[Timestamp] = Encoder.encodeString.contramap(
-    _.value.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"))
-  )
-  implicit val decoder: Decoder[Timestamp] = Decoder.decodeString.emap { str =>
-    try
-      Right(Timestamp(OffsetDateTime.parse(str)))
-    catch {
-      case _: Exception => Left("Invalid timestamp format")
+  def now[F[_]: Clock: Functor]: F[Timestamp] =
+    Clock[F].realTime.map { d =>
+      Timestamp(OffsetDateTime.ofInstant(Instant.ofEpochMilli(d.toMillis), ZoneOffset.UTC))
     }
+
+  def isWithinTTL[F[_]: Clock: Functor](timestamp: Timestamp, ttl: FiniteDuration): F[Boolean] =
+    now[F].map { currentTime =>
+      val diff = Duration.between(timestamp.value, currentTime.value)
+      diff.compareTo(Duration.ofSeconds(ttl.toSeconds)) < 0
+    }
+
+  def older(t1: Timestamp, t2: Timestamp): Timestamp =
+    if (t1.value.isBefore(t2.value)) t1 else t2
+
+  private val fmt: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT
+
+  implicit val encoder: Encoder[Timestamp] =
+    Encoder.encodeString.contramap(timestamp => fmt.format(timestamp.value.toInstant))
+
+  implicit val decoder: Decoder[Timestamp] = Decoder.decodeString.emap { str =>
+    Either
+      .catchNonFatal(Instant.parse(str))
+      .map(i => Timestamp(OffsetDateTime.ofInstant(i, ZoneOffset.UTC)))
+      .leftMap(_ => "Invalid timestamp format")
   }
 }

--- a/forex-mtl/src/main/scala/forex/domain/rates/Timestamp.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Timestamp.scala
@@ -11,7 +11,6 @@ import java.time.format.DateTimeFormatter
 import scala.concurrent.duration.FiniteDuration
 
 final case class Timestamp(value: OffsetDateTime) extends AnyVal
-
 object Timestamp {
 
   def now[F[_]: Clock: Functor]: F[Timestamp] =

--- a/forex-mtl/src/main/scala/forex/http/health/HealthRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/health/HealthRoutes.scala
@@ -6,7 +6,7 @@ import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
 
-class HealthRoutes[F[_]: Sync] extends Http4sDsl[F] {
+final class HealthRoutes[F[_]: Sync] extends Http4sDsl[F] {
 
   private[health] val prefixPath = "/health"
 

--- a/forex-mtl/src/main/scala/forex/http/rates/RatesRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/RatesRoutes.scala
@@ -11,7 +11,7 @@ import org.http4s.server.Router
 import org.http4s.{ HttpRoutes, Method }
 import org.http4s.headers.Allow
 
-class RatesRoutes[F[_]: Sync](ratesProgram: RatesProgram[F]) extends Http4sDsl[F] {
+final class RatesRoutes[F[_]: Sync](ratesProgram: RatesProgram[F]) extends Http4sDsl[F] {
 
   import Converters._, QueryParams._, Protocol._
 

--- a/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
@@ -7,7 +7,7 @@ import forex.domain.error.AppError
 import forex.domain.rates.{ Price, Rate, Timestamp }
 import forex.services.RatesService
 
-class Program[F[_]: Applicative: Clock](ratesService: RatesService[F]) extends Algebra[F] {
+final class Program[F[_]: Applicative: Clock](ratesService: RatesService[F]) extends Algebra[F] {
 
   override def get(request: Protocol.GetRatesRequest): F[AppError Either Rate] = {
     val pair = Rate.Pair(request.from, request.to)

--- a/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
@@ -1,20 +1,21 @@
 package forex.programs.rates
 
 import cats.Applicative
+import cats.effect.Clock
 import cats.syntax.all._
 import forex.domain.error.AppError
 import forex.domain.rates.{ Price, Rate, Timestamp }
 import forex.services.RatesService
 
-class Program[F[_]: Applicative](ratesService: RatesService[F]) extends Algebra[F] {
+class Program[F[_]: Applicative: Clock](ratesService: RatesService[F]) extends Algebra[F] {
 
   override def get(request: Protocol.GetRatesRequest): F[AppError Either Rate] = {
     val pair = Rate.Pair(request.from, request.to)
 
     if (pair.from == pair.to) {
-      Rate(pair, Price(1.0), Timestamp.now)
-        .asRight[AppError]
-        .pure[F]
+      Timestamp.now[F].map { ts =>
+        Rate(pair, Price(1.0), ts).asRight[AppError]
+      }
     } else {
       ratesService.get(pair)
     }
@@ -23,5 +24,5 @@ class Program[F[_]: Applicative](ratesService: RatesService[F]) extends Algebra[
 }
 
 object Program {
-  def apply[F[_]: Applicative](ratesService: RatesService[F]): Algebra[F] = new Program[F](ratesService)
+  def apply[F[_]: Applicative: Clock](ratesService: RatesService[F]): Algebra[F] = new Program[F](ratesService)
 }

--- a/forex-mtl/src/main/scala/forex/services/cache/Service.scala
+++ b/forex-mtl/src/main/scala/forex/services/cache/Service.scala
@@ -9,7 +9,7 @@ import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.FiniteDuration
 
-class Service[F[_]: Sync: Logger](maxSize: Long, ttl: FiniteDuration) extends Algebra[F] {
+final class Service[F[_]: Sync: Logger](maxSize: Long, ttl: FiniteDuration) extends Algebra[F] {
 
   private val cache = Scaffeine()
     .maximumSize(maxSize)

--- a/forex-mtl/src/main/scala/forex/services/rates/Service.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Service.scala
@@ -17,7 +17,7 @@ import forex.services.rates.{ errors => Error }
 
 import scala.concurrent.duration._
 
-class Service[F[_]: Concurrent: Logger: Clock](
+final class Service[F[_]: Concurrent: Logger: Clock](
     oneFrameClient: OneFrameClient[F],
     cache: CacheAlgebra[F],
     locks: BucketLocks[F],

--- a/forex-mtl/src/test/scala/forex/domain/cache/PivotRateSpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/cache/PivotRateSpec.scala
@@ -6,7 +6,7 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import munit.FunSuite
 
-import java.time.OffsetDateTime
+import java.time.{ OffsetDateTime, ZoneOffset }
 
 class PivotRateSpec extends FunSuite {
 
@@ -27,7 +27,7 @@ class PivotRateSpec extends FunSuite {
 
     assertEquals(pivotRate.currency, currency)
     assertEquals(pivotRate.price.value, BigDecimal(1))
-    assert(pivotRate.timestamp.value.getOffset == java.time.ZoneOffset.UTC)
+    assert(pivotRate.timestamp.value.getOffset == ZoneOffset.UTC)
   }
 
   test("fromResponse should create PivotRate from OneFrame response") {

--- a/forex-mtl/src/test/scala/forex/domain/rates/PriceSpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/rates/PriceSpec.scala
@@ -12,7 +12,7 @@ class PriceSpec extends FunSuite {
   }
 
   test("Price should handle Integer conversion") {
-    val price = Price(42: Integer)
+    val price = Price.fromInt(42)
     assertEquals(price.value, BigDecimal(42))
   }
 

--- a/forex-mtl/src/test/scala/forex/domain/rates/PriceSpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/rates/PriceSpec.scala
@@ -12,7 +12,7 @@ class PriceSpec extends FunSuite {
   }
 
   test("Price should handle Integer conversion") {
-    val price = Price.fromInt(42)
+    val price = Price.fromInt(42).toOption.get
     assertEquals(price.value, BigDecimal(42))
   }
 

--- a/forex-mtl/src/test/scala/forex/domain/rates/RateSpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/rates/RateSpec.scala
@@ -17,7 +17,7 @@ class RateSpec extends FunSuite {
     )
     val rate2 = Rate(
       pair = Rate.Pair(Currency.EUR, Currency.GBP),
-      price = Price.fromInt(priceInt),
+      price = Price.fromInt(priceInt).toOption.get,
       timestamp = Timestamp(OffsetDateTime.parse("2024-08-04T15:00:00Z"))
     )
 

--- a/forex-mtl/src/test/scala/forex/domain/rates/RateSpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/rates/RateSpec.scala
@@ -17,7 +17,7 @@ class RateSpec extends FunSuite {
     )
     val rate2 = Rate(
       pair = Rate.Pair(Currency.EUR, Currency.GBP),
-      price = Price(priceInt),
+      price = Price.fromInt(priceInt),
       timestamp = Timestamp(OffsetDateTime.parse("2024-08-04T15:00:00Z"))
     )
 


### PR DESCRIPTION
## Summary

Correct HTTP mapping for upstream failures; make time handling FP-safe, tighten domain/API safety.

## Changes

* `ErrorMapper`:
  * `UpstreamAuthFailed` → **502 Bad Gateway**
  * `UpstreamUnavailable` → **503 Service Unavailable**
  * (Keep: 400/404/422/429/502/500 as before)
* `Timestamp`: remove impure `now`; add `now[F: Clock]`, JSON uses **ISO\_INSTANT (UTC)**.
* `Price`: drop `apply(Integer)`,  add safe constructors (`fromInt`/`fromBigDecimal`) with validation.
* Mark concrete classes `final` (Program/Service/HttpClient/Routes/etc.).

## Testing

* Unit: assert error→HTTP mapping table, `Timestamp` encode/decode round-trip, `Price` decoding (ints/decimals) and rejection of negatives.
* Integration (recommended): stub upstream → verify `403/401` maps to **502**, downtime/timeout maps to **503**; cache hit reduces upstream calls.

