### PR TITLE
style: Improvement - Sort imports across project (no functional change)

### DIFF
--- a/forex-mtl/src/main/scala/forex/Main.scala
+++ b/forex-mtl/src/main/scala/forex/Main.scala
@@ -1,10 +1,11 @@
 package forex
 
 import cats.effect.{ IO, IOApp, Resource, Sync }
-import forex.config.Config
-import forex.modules.{ HttpClientBuilder, HttpServerBuilder }
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import forex.config.Config
+import forex.modules.{ HttpClientBuilder, HttpServerBuilder }
 
 object Main extends IOApp.Simple {
 

--- a/forex-mtl/src/main/scala/forex/Module.scala
+++ b/forex-mtl/src/main/scala/forex/Module.scala
@@ -3,6 +3,11 @@ package forex
 import cats.effect.{ Async, Resource }
 import cats.syntax.functor._
 import cats.syntax.semigroupk._
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.server.middleware.{ AutoSlash, Timeout }
+import org.typelevel.log4cats.Logger
+
 import forex.clients.OneFrameClient
 import forex.config.{ ApplicationConfig, Environment }
 import forex.http.health.HealthRoutes
@@ -11,10 +16,6 @@ import forex.http.rates.RatesRoutes
 import forex.programs.RatesProgram
 import forex.services.{ CacheService, RatesService }
 import forex.services.rates.concurrent.BucketLocks
-import org.http4s._
-import org.http4s.client.Client
-import org.http4s.server.middleware.{ AutoSlash, Timeout }
-import org.typelevel.log4cats.Logger
 
 final class Module[F[_]: Async: Logger](config: ApplicationConfig, httpClient: Client[F], locks: BucketLocks[F]) {
 

--- a/forex-mtl/src/main/scala/forex/clients/oneframe/Algebra.scala
+++ b/forex-mtl/src/main/scala/forex/clients/oneframe/Algebra.scala
@@ -1,8 +1,8 @@
 package forex.clients.oneframe
 
-import forex.domain.rates.Rate
 import forex.clients.oneframe.Protocol.OneFrameRatesResponse
 import forex.domain.error.AppError
+import forex.domain.rates.Rate
 
 trait Algebra[F[_]] {
   def getRates(pairs: List[Rate.Pair]): F[AppError Either OneFrameRatesResponse]

--- a/forex-mtl/src/main/scala/forex/clients/oneframe/Interpreters.scala
+++ b/forex-mtl/src/main/scala/forex/clients/oneframe/Interpreters.scala
@@ -2,11 +2,12 @@ package forex.clients.oneframe
 
 import cats.Applicative
 import cats.effect.Concurrent
-import forex.config.OneFrameConfig
-import forex.clients.oneframe.interpreter.{ HttpClient, MockClient }
-import forex.clients.OneFrameClient
 import org.http4s.client.Client
 import org.typelevel.log4cats.Logger
+
+import forex.clients.OneFrameClient
+import forex.clients.oneframe.interpreter.{ HttpClient, MockClient }
+import forex.config.OneFrameConfig
 
 object Interpreters {
   def httpClient[F[_]: Concurrent: Logger](

--- a/forex-mtl/src/main/scala/forex/clients/oneframe/RequestBuilder.scala
+++ b/forex-mtl/src/main/scala/forex/clients/oneframe/RequestBuilder.scala
@@ -1,8 +1,9 @@
 package forex.clients.oneframe
 
-import forex.domain.rates.Rate
 import org.http4s._
 import org.typelevel.ci.CIStringSyntax
+
+import forex.domain.rates.Rate
 
 final case class RequestBuilder(host: String, port: Int, token: String) {
 

--- a/forex-mtl/src/main/scala/forex/clients/oneframe/errors.scala
+++ b/forex-mtl/src/main/scala/forex/clients/oneframe/errors.scala
@@ -1,10 +1,10 @@
 package forex.clients.oneframe
 
-import forex.domain.error.AppError
-
 import java.io.IOException
 import java.net.{ ConnectException, SocketTimeoutException }
 import java.util.concurrent.TimeoutException
+
+import forex.domain.error.AppError
 
 object errors {
 

--- a/forex-mtl/src/main/scala/forex/clients/oneframe/interpreter/HttpClient.scala
+++ b/forex-mtl/src/main/scala/forex/clients/oneframe/interpreter/HttpClient.scala
@@ -2,15 +2,16 @@ package forex.clients.oneframe.interpreter
 
 import cats.effect.Concurrent
 import cats.syntax.all._
+import io.circe.parser.decode
+import org.http4s.client.Client
+import org.typelevel.log4cats.Logger
+
 import forex.clients.oneframe.{ Algebra, RequestBuilder }
 import forex.clients.oneframe.Protocol.{ OneFrameApiError, OneFrameRatesResponse }
 import forex.clients.oneframe.{ errors => Error }
 import forex.config.OneFrameConfig
 import forex.domain.error.AppError
 import forex.domain.rates.Rate
-import io.circe.parser.decode
-import org.http4s.client.Client
-import org.typelevel.log4cats.Logger
 
 final class HttpClient[F[_]: Concurrent: Logger](client: Client[F], config: OneFrameConfig, token: String)
     extends Algebra[F] {

--- a/forex-mtl/src/main/scala/forex/config/ApplicationConfig.scala
+++ b/forex-mtl/src/main/scala/forex/config/ApplicationConfig.scala
@@ -1,8 +1,8 @@
 package forex.config
 
-import com.comcast.ip4s.{ Host, Port }
-
 import scala.concurrent.duration.FiniteDuration
+
+import com.comcast.ip4s.{ Host, Port }
 
 final case class ApplicationConfig(
     environment: Environment,

--- a/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
+++ b/forex-mtl/src/main/scala/forex/domain/rates/Price.scala
@@ -1,8 +1,8 @@
 package forex.domain.rates
 
-import io.circe.{ Decoder, Encoder }
-
 import scala.math.BigDecimal.RoundingMode
+
+import io.circe.{ Decoder, Encoder }
 
 final case class Price(value: BigDecimal) extends AnyVal
 object Price {

--- a/forex-mtl/src/main/scala/forex/http/health/HealthRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/health/HealthRoutes.scala
@@ -1,10 +1,11 @@
 package forex.http.health
 
 import cats.Monad
-import forex.http.health.Protocol.HealthResponse
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
+
+import forex.http.health.Protocol.HealthResponse
 
 final class HealthRoutes[F[_]: Monad] extends Http4sDsl[F] {
 

--- a/forex-mtl/src/main/scala/forex/http/middleware/ErrorHandlerMiddleware.scala
+++ b/forex-mtl/src/main/scala/forex/http/middleware/ErrorHandlerMiddleware.scala
@@ -4,11 +4,12 @@ import cats.MonadThrow
 import cats.implicits.catsSyntaxApplicativeId
 import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
-import forex.http.util.ErrorResponse
-import org.http4s._
-import org.http4s.dsl.Http4sDsl
-import org.http4s.circe._
 import io.circe.syntax._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
+
+import forex.http.util.ErrorResponse
 
 object ErrorHandlerMiddleware {
   def apply[F[_]: MonadThrow](routes: HttpRoutes[F]): HttpRoutes[F] = {

--- a/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
@@ -1,11 +1,12 @@
 package forex.http
 package rates
 
-import forex.domain.currency.Currency
-import forex.domain.rates.{ Price, Timestamp }
+import io.circe.Encoder
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
-import io.circe.Encoder
+
+import forex.domain.currency.Currency
+import forex.domain.rates.{ Price, Timestamp }
 
 object Protocol {
 

--- a/forex-mtl/src/main/scala/forex/http/rates/QueryParams.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/QueryParams.scala
@@ -1,10 +1,11 @@
 package forex.http.rates
 
 import cats.syntax.bifunctor._
-import forex.domain.currency.Currency
-import forex.domain.currency.errors.CurrencyError
 import org.http4s.QueryParamDecoder
 import org.http4s.dsl.impl.OptionalValidatingQueryParamDecoderMatcher
+
+import forex.domain.currency.Currency
+import forex.domain.currency.errors.CurrencyError
 
 object QueryParams {
   implicit val currencyQueryParamDecoder: QueryParamDecoder[Currency] =

--- a/forex-mtl/src/main/scala/forex/http/rates/QueryValidator.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/QueryValidator.scala
@@ -2,8 +2,9 @@ package forex.http.rates
 
 import cats.data.{ Validated, ValidatedNel }
 import cats.syntax.all._
-import forex.domain.currency.Currency
 import org.http4s.ParseFailure
+
+import forex.domain.currency.Currency
 
 object QueryValidator {
 

--- a/forex-mtl/src/main/scala/forex/http/rates/RatesRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/RatesRoutes.scala
@@ -1,15 +1,16 @@
 package forex.http.rates
 
-import cats.data.Validated.{ Invalid, Valid }
 import cats.Monad
+import cats.data.Validated.{ Invalid, Valid }
 import cats.syntax.flatMap._
-import forex.http.util.ErrorMapper
-import forex.programs.RatesProgram
-import forex.programs.rates.Protocol.GetRatesRequest
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
 import org.http4s.{ HttpRoutes, Method }
 import org.http4s.headers.Allow
+
+import forex.http.util.ErrorMapper
+import forex.programs.RatesProgram
+import forex.programs.rates.Protocol.GetRatesRequest
 
 final class RatesRoutes[F[_]: Monad](ratesProgram: RatesProgram[F]) extends Http4sDsl[F] {
 

--- a/forex-mtl/src/main/scala/forex/http/util/ErrorMapper.scala
+++ b/forex-mtl/src/main/scala/forex/http/util/ErrorMapper.scala
@@ -2,9 +2,10 @@ package forex.http.util
 
 import cats.Applicative
 import cats.syntax.applicative._
-import forex.domain.error.AppError
 import org.http4s.{ Method, Response, Status }
 import org.http4s.headers.Allow
+
+import forex.domain.error.AppError
 
 object ErrorMapper {
 

--- a/forex-mtl/src/main/scala/forex/modules/HttpServerBuilder.scala
+++ b/forex-mtl/src/main/scala/forex/modules/HttpServerBuilder.scala
@@ -1,12 +1,13 @@
 package forex.modules
 
 import cats.effect.{ Async, Resource }
-import forex.config.HttpConfig
 import org.http4s.HttpApp
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server
 import org.http4s.server.defaults.Banner
 import org.typelevel.log4cats.Logger
+
+import forex.config.HttpConfig
 
 object HttpServerBuilder {
 

--- a/forex-mtl/src/main/scala/forex/services/cache/errors.scala
+++ b/forex-mtl/src/main/scala/forex/services/cache/errors.scala
@@ -1,9 +1,9 @@
 package forex.services.cache
 
-import forex.domain.error.AppError
-
 import java.io.IOException
 import java.util.concurrent.TimeoutException
+
+import forex.domain.error.AppError
 
 object errors {
 

--- a/forex-mtl/src/main/scala/forex/services/rates/concurrent/BucketLocks.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/concurrent/BucketLocks.scala
@@ -4,6 +4,7 @@ import cats.effect.Concurrent
 import cats.effect.std.Semaphore
 import cats.syntax.flatMap._
 import cats.syntax.functor._
+
 import forex.domain.cache.FetchStrategy
 
 final class BucketLocks[F[_]: Concurrent](most: Semaphore[F], other: Semaphore[F]) {

--- a/forex-mtl/src/test/scala/forex/ModuleSpec.scala
+++ b/forex-mtl/src/test/scala/forex/ModuleSpec.scala
@@ -1,16 +1,18 @@
 package forex
 
+import scala.concurrent.duration._
+
 import cats.effect.{ IO, Resource }
-import forex.config.{ ApplicationConfig, Environment }
-import forex.config.{ CacheConfig, HttpConfig, OneFrameConfig, SecretConfig }
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.typelevel.log4cats.Logger
 import com.comcast.ip4s.{ Host, Port }
+import munit.CatsEffectSuite
 import org.http4s.{ HttpApp, Response, Status }
 import org.http4s.client.Client
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import forex.config.{ ApplicationConfig, Environment }
+import forex.config.{ CacheConfig, HttpConfig, OneFrameConfig, SecretConfig }
 import forex.services.rates.concurrent.BucketLocks
-import scala.concurrent.duration._
 
 class ModuleSpec extends CatsEffectSuite {
 

--- a/forex-mtl/src/test/scala/forex/clients/oneframe/ErrorsSpec.scala
+++ b/forex-mtl/src/test/scala/forex/clients/oneframe/ErrorsSpec.scala
@@ -1,10 +1,12 @@
 package forex.clients.oneframe
 
-import forex.domain.error.AppError
-import munit.FunSuite
 import java.io.IOException
 import java.net.{ ConnectException, SocketTimeoutException }
 import java.util.concurrent.TimeoutException
+
+import munit.FunSuite
+
+import forex.domain.error.AppError
 
 class ErrorsSpec extends FunSuite {
 

--- a/forex-mtl/src/test/scala/forex/clients/oneframe/HttpClientSpec.scala
+++ b/forex-mtl/src/test/scala/forex/clients/oneframe/HttpClientSpec.scala
@@ -1,15 +1,16 @@
 package forex.clients.oneframe
 
 import cats.effect.IO
-import forex.domain.currency.Currency
-import forex.domain.rates.Rate
-import forex.domain.error.AppError
+import munit.CatsEffectSuite
+import org.http4s.client.Client
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
 import forex.clients.oneframe.interpreter.HttpClient
 import forex.config.OneFrameConfig
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.typelevel.log4cats.Logger
-import org.http4s.client.Client
+import forex.domain.currency.Currency
+import forex.domain.error.AppError
+import forex.domain.rates.Rate
 
 class HttpClientSpec extends CatsEffectSuite {
 

--- a/forex-mtl/src/test/scala/forex/clients/oneframe/MockClientSpec.scala
+++ b/forex-mtl/src/test/scala/forex/clients/oneframe/MockClientSpec.scala
@@ -1,12 +1,13 @@
 package forex.clients.oneframe
 
 import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import forex.clients.oneframe.interpreter.MockClient
 import forex.domain.currency.Currency
 import forex.domain.rates.Rate
-import forex.clients.oneframe.interpreter.MockClient
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.typelevel.log4cats.Logger
 
 class MockClientSpec extends CatsEffectSuite {
 

--- a/forex-mtl/src/test/scala/forex/clients/oneframe/RequestBuilderSpec.scala
+++ b/forex-mtl/src/test/scala/forex/clients/oneframe/RequestBuilderSpec.scala
@@ -1,10 +1,11 @@
 package forex.clients.oneframe
 
 import cats.effect.IO
+import munit.CatsEffectSuite
+
+import forex.config.OneFrameConfig
 import forex.domain.currency.Currency
 import forex.domain.rates.Rate
-import forex.config.OneFrameConfig
-import munit.CatsEffectSuite
 
 class RequestBuilderSpec extends CatsEffectSuite {
 

--- a/forex-mtl/src/test/scala/forex/config/ConfigSpec.scala
+++ b/forex-mtl/src/test/scala/forex/config/ConfigSpec.scala
@@ -1,8 +1,9 @@
 package forex.config
 
-import munit.FunSuite
 import scala.concurrent.duration._
+
 import com.comcast.ip4s.{ Host, Port }
+import munit.FunSuite
 
 class ConfigSpec extends FunSuite {
 

--- a/forex-mtl/src/test/scala/forex/domain/currency/CurrencySpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/currency/CurrencySpec.scala
@@ -1,6 +1,7 @@
 package forex.domain.currency
 
 import munit.FunSuite
+
 import forex.domain.currency.errors.CurrencyError
 
 class CurrencySpec extends FunSuite {

--- a/forex-mtl/src/test/scala/forex/domain/currency/ErrorsSpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/currency/ErrorsSpec.scala
@@ -1,6 +1,7 @@
 package forex.domain.currency
 
 import munit.FunSuite
+
 import forex.domain.currency.errors.CurrencyError
 
 class ErrorsSpec extends FunSuite {

--- a/forex-mtl/src/test/scala/forex/http/health/HealthRoutesSpec.scala
+++ b/forex-mtl/src/test/scala/forex/http/health/HealthRoutesSpec.scala
@@ -1,10 +1,10 @@
 package forex.http.health
 
 import cats.effect.IO
+import io.circe.parser._
 import munit.CatsEffectSuite
 import org.http4s._
 import org.http4s.implicits._
-import io.circe.parser._
 
 class HealthRoutesSpec extends CatsEffectSuite {
 

--- a/forex-mtl/src/test/scala/forex/http/middleware/ErrorHandlerMiddlewareSpec.scala
+++ b/forex-mtl/src/test/scala/forex/http/middleware/ErrorHandlerMiddlewareSpec.scala
@@ -1,8 +1,8 @@
 package forex.http.middleware
 
 import cats.effect.IO
-import munit.CatsEffectSuite
 import io.circe.parser._
+import munit.CatsEffectSuite
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.implicits._

--- a/forex-mtl/src/test/scala/forex/http/rates/QueryParamsSpec.scala
+++ b/forex-mtl/src/test/scala/forex/http/rates/QueryParamsSpec.scala
@@ -1,9 +1,10 @@
 package forex.http.rates
 
-import forex.domain.currency.Currency
-import org.http4s.QueryParameterValue
 import cats.data.Validated
 import munit.FunSuite
+import org.http4s.QueryParameterValue
+
+import forex.domain.currency.Currency
 
 class QueryParamsSpec extends FunSuite {
 

--- a/forex-mtl/src/test/scala/forex/http/rates/QueryValidatorSpec.scala
+++ b/forex-mtl/src/test/scala/forex/http/rates/QueryValidatorSpec.scala
@@ -1,9 +1,10 @@
 package forex.http.rates
 
-import forex.domain.currency.Currency
-import org.http4s.ParseFailure
 import cats.data.{ NonEmptyList, Validated, ValidatedNel }
 import munit.FunSuite
+import org.http4s.ParseFailure
+
+import forex.domain.currency.Currency
 
 class QueryValidatorSpec extends FunSuite {
 

--- a/forex-mtl/src/test/scala/forex/http/util/ErrorMapperSpec.scala
+++ b/forex-mtl/src/test/scala/forex/http/util/ErrorMapperSpec.scala
@@ -1,10 +1,11 @@
 package forex.http.util
 
 import cats.effect.IO
-import forex.domain.error.AppError
 import munit.CatsEffectSuite
 import org.http4s.{ Method, Status }
 import org.http4s.headers.Allow
+
+import forex.domain.error.AppError
 
 class ErrorMapperSpec extends CatsEffectSuite {
 

--- a/forex-mtl/src/test/scala/forex/services/cache/ErrorsSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/cache/ErrorsSpec.scala
@@ -1,10 +1,11 @@
 package forex.services.cache
 
-import forex.domain.error.AppError
-import munit.FunSuite
-
 import java.io.IOException
 import java.util.concurrent.TimeoutException
+
+import munit.FunSuite
+
+import forex.domain.error.AppError
 
 class ErrorsSpec extends FunSuite {
 

--- a/forex-mtl/src/test/scala/forex/services/rates/concurrent/BucketLocksSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/concurrent/BucketLocksSpec.scala
@@ -1,8 +1,9 @@
 package forex.services.rates.concurrent
 
 import cats.effect.IO
-import forex.domain.cache.FetchStrategy
 import munit.CatsEffectSuite
+
+import forex.domain.cache.FetchStrategy
 
 class BucketLocksSpec extends CatsEffectSuite {
 


### PR DESCRIPTION
## Summary

* Reorder imports for consistency/readability across touched files. No functional changes.

## Changes

* Alphabetize and group imports (java/scala → third-party → project).
* Remove unused/duplicate imports.
* Apply the same ordering convention across modules and tests.

## Testing

* Ran `sbt compile` and `sbt test` to ensure build stays green.
* No new tests; change is formatting-only.

